### PR TITLE
Legger til tilgang for aia-backend

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -52,6 +52,8 @@ spec:
           namespace: paw
         - application: bakveientilarbeid
           namespace: paw
+        - application: aia-backend
+          namespace: paw
   tokenx:
     enabled: true
   azure:


### PR DESCRIPTION
Legger til tilgang for [aia-backend](https://github.com/navikt/aia-backend).

aia-backend skal på sikt ta over for bakveientilarbeid