### PR TITLE
fix(resources): reduser OOMKilled-risiko i dp-innsyn

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -29,9 +29,9 @@ spec:
     enabled: true
   resources:
     limits:
-      memory: 1Gi
+      memory: 1280Mi
     requests:
-      cpu: 133m
+      cpu: 100m
       memory: 1Gi
   kafka:
     pool: "{{kafka_pool}}"
@@ -56,6 +56,8 @@ spec:
     outbound:
       rules:
         - application: dp-soknad
+        - application: logging
+          namespace: nais-system
   tokenx:
     enabled: true
   azure:
@@ -79,8 +81,8 @@ spec:
             envVarPrefix: DB
         cascadingDelete: false
   env:
-    - name: JAVA_TOOL_OPTIONS
-      value: "-XX:MaxRAMPercentage=75.0 -XX:InitialRAMPercentage=50.0"
+    - name: JDK_JAVA_OPTIONS
+      value: -XX:+UseParallelGC -XX:MaxRAMPercentage=50.0 -XX:ActiveProcessorCount=4
     - name: DP_SOKNAD_URL
       value:  "{{dp_soknad.url}}"
     - name: DP_SOKNAD_AUDIENCE

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresDataSourceBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresDataSourceBuilder.kt
@@ -12,6 +12,8 @@ import com.zaxxer.hikari.HikariDataSource
 import no.nav.dagpenger.innsyn.Configuration
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.configuration.FluentConfiguration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 private val config = ConfigurationProperties.systemProperties() overriding EnvironmentVariables()
 
@@ -34,10 +36,15 @@ internal object PostgresDataSourceBuilder {
             addDataSourceProperty("user", config[db.username])
             addDataSourceProperty("password", config[db.password])
             maximumPoolSize = 10
-            minimumIdle = 1
-            idleTimeout = 10001
-            connectionTimeout = 1000
-            maxLifetime = 30001
+            // Default 30 sekund
+            connectionTimeout = 10.seconds.inWholeMilliseconds
+            // Default 10 minutter
+            idleTimeout = 10.minutes.inWholeMilliseconds
+            // Default 2 minutter
+            keepaliveTime = 2.minutes.inWholeMilliseconds
+            // Default 30 minutter
+            maxLifetime = 30.minutes.inWholeMilliseconds
+            leakDetectionThreshold = 30.seconds.inWholeMilliseconds
         }
     }
 


### PR DESCRIPTION
 - Øker memory limit fra 1Gi til 1280Mi for å gi headroom til JVM, OTel-agent og off-heap overhead
 - Bytter fra JAVA_TOOL_OPTIONS til JDK_JAVA_OPTIONS og setter MaxRAMPercentage=50.0 for eksplisitt heap-styring (~512MB)
 - Justerer CPU request fra 133m til 100m
 - Setter riktige HikariCP-timeouts med Kotlin Duration API: connectionTimeout=10s, idleTimeout=10min, maxLifetime=30min
 - Legger til keepaliveTime=2min og leakDetectionThreshold=30s
 - Legger til logging (nais-system) i outbound accessPolicy (den manglet)