### PR TITLE
Unngå full personlast ved mottak av vedtak

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/PersonMediator.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/PersonMediator.kt
@@ -37,9 +37,7 @@ internal class PersonMediator(
         vedtak: Vedtak,
         melding: Vedtaksmelding,
     ) {
-        håndter(melding) { person ->
-            person.håndter(vedtak)
-        }
+        personRepository.lagreVedtak(melding.fødselsnummer, vedtak)
     }
 
     fun håndter(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PersonRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.innsyn.db
 
 import no.nav.dagpenger.innsyn.modell.Person
+import no.nav.dagpenger.innsyn.modell.hendelser.Vedtak
 
 interface PersonRepository :
     SøknadRepository,
@@ -8,4 +9,9 @@ interface PersonRepository :
     fun person(fnr: String): Person
 
     fun lagre(person: Person): Boolean
+
+    fun lagreVedtak(
+        fnr: String,
+        vedtak: Vedtak,
+    )
 }

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
@@ -17,6 +17,7 @@ import no.nav.dagpenger.innsyn.modell.hendelser.Søknad.SøknadsType
 import no.nav.dagpenger.innsyn.modell.hendelser.Vedtak
 import no.nav.dagpenger.innsyn.modell.serde.PersonData
 import no.nav.dagpenger.innsyn.modell.serde.PersonVisitor
+import no.nav.dagpenger.innsyn.modell.serde.VedtakVisitor
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -32,6 +33,56 @@ class PostgresPersonRepository : PersonRepository {
                     .map {
                         tx.run(it.asUpdate)
                     }.all { it >= 1 }
+            }
+        }
+    }
+
+    override fun lagreVedtak(
+        fnr: String,
+        vedtak: Vedtak,
+    ) {
+        var vedtakQuery: Query? = null
+        vedtak.accept(
+            object : VedtakVisitor {
+                override fun visitVedtak(
+                    vedtakId: String,
+                    fagsakId: String,
+                    status: Vedtak.Status,
+                    datoFattet: LocalDateTime,
+                    fraDato: LocalDateTime,
+                    tilDato: LocalDateTime?,
+                ) {
+                    vedtakQuery =
+                        queryOf(
+                            //language=PostgreSQL
+                            """
+                            INSERT INTO vedtak(person_id, vedtak_id, fagsak_id, status, fattet, fra_dato, til_dato)
+                            VALUES ((SELECT person_id FROM person WHERE fnr = :fnr), :vedtakId, :fagsakId, :status, :fattet, :fraDato, :tilDato)
+                            ON CONFLICT DO NOTHING
+                            """.trimIndent(),
+                            mapOf(
+                                "fnr" to fnr,
+                                "vedtakId" to vedtakId,
+                                "fagsakId" to fagsakId,
+                                "status" to status.toString(),
+                                "fattet" to datoFattet,
+                                "fraDato" to fraDato,
+                                "tilDato" to tilDato,
+                            ),
+                        )
+                }
+            },
+        )
+        using(sessionOf(dataSource)) { session ->
+            session.transaction { tx ->
+                tx.run(
+                    queryOf(
+                        //language=PostgreSQL
+                        "INSERT INTO person (fnr) VALUES (:fnr) ON CONFLICT DO NOTHING",
+                        mapOf("fnr" to fnr),
+                    ).asUpdate,
+                )
+                tx.run(requireNotNull(vedtakQuery) { "vedtakQuery ble ikke satt av VedtakVisitor" }.asUpdate)
             }
         }
     }


### PR DESCRIPTION
Vedtak-flyten brukte det generiske load-muter-lagre-mønsteret (person() → person.håndter(vedtak) → lagre(person)) som ble innebygd for alle event-typer. For vedtak er det unødvendig: Person.håndter(vedtak) gjør kun add(), ingen kryssjekk mot eksisterende tilstand.

Under en CDC-replay-storm på SIAMO.VEDTAK bygde PersonLagrer opp hundrevis av Query-objekter per melding – én per søknad, vedlegg og vedtak i hele personens historikk – som sprengte heap-en med OOM i extractNamedParamsIndexed.

Løsning: ny lagreVedtak(fnr, vedtak) i PersonRepository som setter inn person og vedtak direkte med to faste spørringer per event (O(1)), uavhengig av historikk-størrelse. PersonLagrer og de øvrige event-flytene (søknad, ettersending,
sakstilknytning) er urørt.