### PR TITLE
perf: løs N+1 i hentSøknaderFor ved å JOIN-e vedlegg

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresDataSourceBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresDataSourceBuilder.kt
@@ -37,7 +37,7 @@ internal object PostgresDataSourceBuilder {
             addDataSourceProperty("password", config[db.password])
             maximumPoolSize = 10
             // Default 30 sekund
-            connectionTimeout = 10.seconds.inWholeMilliseconds
+            connectionTimeout = 5.seconds.inWholeMilliseconds
             // Default 10 minutter
             idleTimeout = 10.minutes.inWholeMilliseconds
             // Default 2 minutter

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresDataSourceBuilder.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresDataSourceBuilder.kt
@@ -40,7 +40,7 @@ internal object PostgresDataSourceBuilder {
             connectionTimeout = 5.seconds.inWholeMilliseconds
             // Default 10 minutter
             idleTimeout = 10.minutes.inWholeMilliseconds
-            // Default 2 minutter
+            // Default 2 minutter.
             keepaliveTime = 2.minutes.inWholeMilliseconds
             // Default 30 minutter
             maxLifetime = 30.minutes.inWholeMilliseconds

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
@@ -6,7 +6,6 @@ import kotliquery.Session
 import kotliquery.param
 import kotliquery.queryOf
 import kotliquery.sessionOf
-import kotliquery.using
 import no.nav.dagpenger.innsyn.db.PostgresDataSourceBuilder.dataSource
 import no.nav.dagpenger.innsyn.modell.Person
 import no.nav.dagpenger.innsyn.modell.hendelser.Innsending.Vedlegg
@@ -26,7 +25,7 @@ class PostgresPersonRepository : PersonRepository {
     override fun lagre(person: Person): Boolean {
         val visitor = PersonLagrer(person)
 
-        return using(sessionOf(dataSource)) { session ->
+        return sessionOf(dataSource).use { session ->
             session.transaction { tx ->
                 visitor.queries
                     .map {
@@ -39,7 +38,7 @@ class PostgresPersonRepository : PersonRepository {
     private fun lagPerson(fnr: String): Person = Person(fnr).also { lagre(it) }
 
     private fun getPerson(fnr: String) =
-        using(sessionOf(dataSource)) { session ->
+        sessionOf(dataSource).use { session ->
             session.run(selectPerson(fnr))?.let {
                 val søknader = hentSøknaderFor(fnr)
                 val vedtak = hentVedtakFor(session, it)
@@ -188,50 +187,86 @@ class PostgresPersonRepository : PersonRepository {
         }
     }
 
+    private data class SøknadRad(
+        val id: Long,
+        val søknadId: String?,
+        val journalpostId: String,
+        val skjemaKode: String,
+        val søknadsType: SøknadsType,
+        val kanal: Kanal,
+        val datoInnsendt: LocalDateTime,
+        val tittel: String?,
+        val vedleggSkjemaNummer: String?,
+        val vedleggNavn: String?,
+        val vedleggStatus: String?,
+    )
+
+    private fun Row.toSøknadRad() =
+        SøknadRad(
+            id = long("id"),
+            søknadId = stringOrNull("søknad_id"),
+            journalpostId = string("journalpost_id"),
+            skjemaKode = string("skjema_kode"),
+            søknadsType = SøknadsType.valueOf(string("søknads_type")),
+            kanal = Kanal.valueOf(string("kanal")),
+            datoInnsendt = localDateTime("dato_innsendt"),
+            tittel = stringOrNull("tittel"),
+            vedleggSkjemaNummer = stringOrNull("skjema_nummer"),
+            vedleggNavn = stringOrNull("vedlegg_navn"),
+            vedleggStatus = stringOrNull("vedlegg_status"),
+        )
+
+    private fun List<SøknadRad>.groupSøknadRader(): List<Søknad> =
+        this
+            .groupBy { it.id }
+            .values
+            .map { rader ->
+                val first = rader.first()
+                val vedlegg =
+                    rader.mapNotNull { rad ->
+                        if (rad.vedleggStatus != null && rad.vedleggNavn != null && rad.vedleggSkjemaNummer != null) {
+                            Vedlegg(
+                                skjemaNummer = rad.vedleggSkjemaNummer,
+                                navn = rad.vedleggNavn,
+                                status = Status.valueOf(rad.vedleggStatus),
+                            )
+                        } else {
+                            null
+                        }
+                    }
+                Søknad(
+                    søknadId = first.søknadId,
+                    journalpostId = first.journalpostId,
+                    skjemaKode = first.skjemaKode,
+                    søknadsType = first.søknadsType,
+                    kanal = first.kanal,
+                    datoInnsendt = first.datoInnsendt,
+                    vedlegg = vedlegg,
+                    tittel = first.tittel,
+                )
+            }
+
     override fun hentSøknaderFor(fnr: String) =
-        using(sessionOf(dataSource)) { session ->
-            session.run(
-                queryOf(
-                    //language=PostgreSQL
-                    """SELECT *
-                        FROM søknad
-                        WHERE person_id = (SELECT person_id FROM person WHERE fnr = ?)
-                    """.trimMargin(),
-                    fnr,
-                ).map { row ->
-                    mapSøknadsRad(row)
-                }.asList,
-            )
-        }
-
-    private fun mapSøknadsRad(row: Row): Søknad {
-        val vedlegg =
-            row
-                .stringOrNull("søknad_id")
-                ?.let {
-                    hentVedleggFor(row.string("søknad_id"))
-                }.orEmpty()
-        return row.toSøknad(vedlegg)
-    }
-
-    override fun hentVedleggFor(søknadsId: String) =
-        using(sessionOf(dataSource)) { session ->
-            session.run(
-                queryOf(
-                    //language=PostgreSQL
-                    """SELECT *
-                        FROM vedlegg 
-                        WHERE søknad_id = ? 
-                    """.trimMargin(),
-                    søknadsId,
-                ).map { row ->
-                    row.toVedlegg()
-                }.asList,
-            )
+        sessionOf(dataSource).use { session ->
+            session
+                .run(
+                    queryOf(
+                        //language=PostgreSQL
+                        """
+                        SELECT s.*, v.skjema_nummer, v.navn AS vedlegg_navn, v.status AS vedlegg_status
+                        FROM søknad s
+                        JOIN person p ON p.person_id = s.person_id
+                        LEFT JOIN vedlegg v ON v.søknad_id = s.søknad_id
+                        WHERE p.fnr = ?
+                        ORDER BY s.dato_innsendt DESC, s.id
+                        """.trimIndent(),
+                        fnr,
+                    ).map { row -> row.toSøknadRad() }.asList,
+                ).groupSøknadRader()
         }
 
     override fun hentVedtakFor(fnr: String) =
-        using(sessionOf(dataSource)) { session ->
+        sessionOf(dataSource).use { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -253,7 +288,7 @@ class PostgresPersonRepository : PersonRepository {
         offset: Int,
         limit: Int,
     ): List<Vedtak> =
-        using(sessionOf(dataSource)) { session ->
+        sessionOf(dataSource).use { session ->
             session.run(
                 queryOf(
                     //language=PostgreSQL
@@ -286,49 +321,31 @@ class PostgresPersonRepository : PersonRepository {
         kanal: List<Kanal>,
         offset: Int,
         limit: Int,
-    ) = using(sessionOf(dataSource)) { session ->
-        session.run(
-            queryOf(
-                //language=PostgreSQL
-                """
-                SELECT *
-                FROM søknad s,
-                     person p
-                WHERE p.person_id = s.person_id
-                  AND p.fnr = :fnr
-                  AND s.dato_innsendt <@ TSRANGE(:fom, :tom) 
-                ORDER BY s.dato_innsendt DESC
-                LIMIT :limit OFFSET :offset
-                """.trimIndent(),
-                mapOf(
-                    "fnr" to fnr.param(),
-                    "fom" to fom,
-                    "tom" to tom?.plusDays(1),
-                    "limit" to limit,
-                    "offset" to offset,
-                ),
-            ).map { row -> mapSøknadsRad(row) }.asList,
-        )
+    ) = sessionOf(dataSource).use { session ->
+        session
+            .run(
+                queryOf(
+                    //language=PostgreSQL
+                    """
+                    SELECT s.*, v.skjema_nummer, v.navn AS vedlegg_navn, v.status AS vedlegg_status
+                    FROM søknad s
+                    JOIN person p ON p.person_id = s.person_id
+                    LEFT JOIN vedlegg v ON v.søknad_id = s.søknad_id
+                    WHERE p.fnr = :fnr
+                      AND s.dato_innsendt <@ TSRANGE(:fom, :tom)
+                    ORDER BY s.dato_innsendt DESC, s.id
+                    LIMIT :limit OFFSET :offset
+                    """.trimIndent(),
+                    mapOf(
+                        "fnr" to fnr.param(),
+                        "fom" to fom,
+                        "tom" to tom?.plusDays(1),
+                        "limit" to limit,
+                        "offset" to offset,
+                    ),
+                ).map { row -> row.toSøknadRad() }.asList,
+            ).groupSøknadRader()
     }
-
-    private fun Row.toSøknad(vedlegg: List<Vedlegg>) =
-        Søknad(
-            søknadId = stringOrNull("søknad_id"),
-            journalpostId = string("journalpost_id"),
-            skjemaKode = string("skjema_kode"),
-            søknadsType = SøknadsType.valueOf(string("søknads_type")),
-            kanal = Kanal.valueOf(string("kanal")),
-            datoInnsendt = localDateTime("dato_innsendt"),
-            vedlegg = vedlegg,
-            tittel = stringOrNull("tittel"),
-        )
-
-    private fun Row.toVedlegg() =
-        Vedlegg(
-            skjemaNummer = string("skjema_nummer"),
-            navn = string("navn"),
-            status = Status.valueOf(string("status")),
-        )
 
     private fun Row.toVedtak() =
         Vedtak(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
@@ -72,7 +72,7 @@ class PostgresPersonRepository : PersonRepository {
                 }
             },
         )
-        using(sessionOf(dataSource)) { session ->
+        sessionOf(dataSource).use { session ->
             session.transaction { tx ->
                 tx.run(
                     queryOf(

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepository.kt
@@ -327,14 +327,19 @@ class PostgresPersonRepository : PersonRepository {
                 queryOf(
                     //language=PostgreSQL
                     """
-                    SELECT s.*, v.skjema_nummer, v.navn AS vedlegg_navn, v.status AS vedlegg_status
-                    FROM søknad s
-                    JOIN person p ON p.person_id = s.person_id
-                    LEFT JOIN vedlegg v ON v.søknad_id = s.søknad_id
-                    WHERE p.fnr = :fnr
-                      AND s.dato_innsendt <@ TSRANGE(:fom, :tom)
-                    ORDER BY s.dato_innsendt DESC, s.id
-                    LIMIT :limit OFFSET :offset
+                    WITH paged_søknad AS (
+                        SELECT s.*
+                        FROM søknad s
+                        JOIN person p ON p.person_id = s.person_id
+                        WHERE p.fnr = :fnr
+                          AND s.dato_innsendt <@ TSRANGE(:fom, :tom)
+                        ORDER BY s.dato_innsendt DESC, s.id
+                        LIMIT :limit OFFSET :offset
+                    )
+                    SELECT ps.*, v.skjema_nummer, v.navn AS vedlegg_navn, v.status AS vedlegg_status
+                    FROM paged_søknad ps
+                    LEFT JOIN vedlegg v ON v.søknad_id = ps.søknad_id
+                    ORDER BY ps.dato_innsendt DESC, ps.id
                     """.trimIndent(),
                     mapOf(
                         "fnr" to fnr.param(),

--- a/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/SøknadRepository.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/innsyn/db/SøknadRepository.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.innsyn.db
 
-import no.nav.dagpenger.innsyn.modell.hendelser.Innsending
 import no.nav.dagpenger.innsyn.modell.hendelser.Kanal
 import no.nav.dagpenger.innsyn.modell.hendelser.Søknad
 import no.nav.dagpenger.innsyn.modell.hendelser.Søknad.SøknadsType
@@ -18,6 +17,4 @@ interface SøknadRepository {
     ): List<Søknad>
 
     fun hentSøknaderFor(fnr: String): List<Søknad>
-
-    fun hentVedleggFor(søknadsId: String): List<Innsending.Vedlegg>
 }

--- a/mediator/src/test/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepositoryTest.kt
@@ -221,31 +221,64 @@ internal class PostgresPersonRepositoryTest {
         withMigratedDb {
             val fnr = "1234567892"
             val person = repository.person(fnr)
-            val søknad =
+            val søknad1 =
                 Søknad(
                     UUID.randomUUID().toString(),
-                    "journalpostId-vedlegg-test",
+                    "journalpostId-vedlegg-test-1",
+                    "NAV01",
+                    Søknad.SøknadsType.NySøknad,
+                    Kanal.Digital,
+                    LocalDateTime.now().minusDays(1),
+                    listOf(
+                        Vedlegg("V1", "Vedlegg én", LastetOpp),
+                        Vedlegg("V2", "Vedlegg to", LastetOpp),
+                    ),
+                    "tittel 1",
+                )
+            val søknad2 =
+                Søknad(
+                    UUID.randomUUID().toString(),
+                    "journalpostId-vedlegg-test-2",
                     "NAV01",
                     Søknad.SøknadsType.NySøknad,
                     Kanal.Digital,
                     LocalDateTime.now(),
                     listOf(
-                        Vedlegg("V1", "Vedlegg én", LastetOpp),
-                        Vedlegg("V2", "Vedlegg to", LastetOpp),
+                        Vedlegg("V3", "Vedlegg tre", LastetOpp),
                     ),
-                    "tittel",
+                    "tittel 2",
                 )
-            person.håndter(søknad)
+            person.håndter(søknad1)
+            person.håndter(søknad2)
             repository.lagre(person)
 
-            val resultat =
+            // limit=1 skal returnere nøyaktig én søknad med alle sine vedlegg —
+            // ikke bli avkortet av at JOIN gir flere rader enn limit
+            val førsteSide =
                 repository.hentSøknaderFor(
                     fnr = fnr,
-                    fom = LocalDate.now().minusDays(1),
+                    fom = LocalDate.now().minusDays(2),
                     tom = LocalDate.now().plusDays(1),
+                    limit = 1,
+                    offset = 0,
                 )
-            assertEquals(1, resultat.size)
-            assertEquals(2, SøknadInspektør(resultat.first()).antallVedlegg)
+            assertEquals(1, førsteSide.size)
+            assertEquals(1, SøknadInspektør(førsteSide.first()).antallVedlegg)
+
+            val andreSide =
+                repository.hentSøknaderFor(
+                    fnr = fnr,
+                    fom = LocalDate.now().minusDays(2),
+                    tom = LocalDate.now().plusDays(1),
+                    limit = 1,
+                    offset = 1,
+                )
+            assertEquals(1, andreSide.size)
+            assertEquals(2, SøknadInspektør(andreSide.first()).antallVedlegg)
+
+            // Ingen overlapp mellom sider
+            val alleIds = (førsteSide + andreSide).map { SøknadInspektør(it).journalpostId }.toSet()
+            assertEquals(2, alleIds.size)
         }
     }
 

--- a/mediator/src/test/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepositoryTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/innsyn/db/PostgresPersonRepositoryTest.kt
@@ -216,6 +216,39 @@ internal class PostgresPersonRepositoryTest {
         }
     }
 
+    @Test
+    fun `hentSøknaderFor med paginering inkluderer vedlegg`() {
+        withMigratedDb {
+            val fnr = "1234567892"
+            val person = repository.person(fnr)
+            val søknad =
+                Søknad(
+                    UUID.randomUUID().toString(),
+                    "journalpostId-vedlegg-test",
+                    "NAV01",
+                    Søknad.SøknadsType.NySøknad,
+                    Kanal.Digital,
+                    LocalDateTime.now(),
+                    listOf(
+                        Vedlegg("V1", "Vedlegg én", LastetOpp),
+                        Vedlegg("V2", "Vedlegg to", LastetOpp),
+                    ),
+                    "tittel",
+                )
+            person.håndter(søknad)
+            repository.lagre(person)
+
+            val resultat =
+                repository.hentSøknaderFor(
+                    fnr = fnr,
+                    fom = LocalDate.now().minusDays(1),
+                    tom = LocalDate.now().plusDays(1),
+                )
+            assertEquals(1, resultat.size)
+            assertEquals(2, SøknadInspektør(resultat.first()).antallVedlegg)
+        }
+    }
+
     private fun assertSøknadEquals(
         expected: Søknad,
         result: Søknad,


### PR DESCRIPTION
Bytter ut separat hentVedleggFor-kall per søknad med én LEFT JOIN-query. Rader materialiseres til SøknadRad data class innenfor map-blokken for å unngå ResultSet-feil etter at session er lukket.

- Fjerner hentVedleggFor fra SøknadRepository-interfacet
- Reduserer HikariCP connectionTimeout fra 10s til 5s
- Legger til test som verifiserer vedlegg i paginert søknad-query
- bytter ut using() fra kotlinquery til .use {} fra kotlin, using har sine issues med at den ikke lukker skikkelig.